### PR TITLE
Add code for swap between 6x3 default and 5x3

### DIFF
--- a/config/corne-ish_zen.keymap
+++ b/config/corne-ish_zen.keymap
@@ -10,6 +10,13 @@
 #include <dt-bindings/zmk/bt.h>
 
 / {
+  chosen {
+    zmk,matrix_transform = &default_transform;
+    //zmk,matrix_transform = &five_column_transform;
+  };
+};
+
+/ {
         keymap {
                 compatible = "zmk,keymap";
 


### PR DESCRIPTION
Added code found in v2 Zen config to allow users to comment out and select between 6x3 and 5x3